### PR TITLE
Enabled paper submission.

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             <li><a href="#about">About</a></li>
             <li><a href="#cfp">Call for Papers</a></li>
             <li><a href="#committee">Committee</a></li>
-            <li class="disabled"><a href="#submission">Submit a Paper</a></li>
+            <li><a href="#submission">Submit a Paper</a></li>
           </ul>
         </div>
       </div>
@@ -101,10 +101,19 @@
         Chris Batten, Cornell<br>
         Luis Ceze, University of Washington<br>
         Tipp Moseley, Google<br>
-        Thomas Wenisch, Univesrity of Michigan<br>
+        Thomas Wenisch, University of Michigan<br>
 
         <h3>Contact</h3>
         <p>Questions? <a href="mailto:contact@nope.pub?subject=Question about the workshop">Send us an email.</a></p>
+      </div>
+
+      <div id="submission" class="container section">
+        <h3>Submission Guidelines</h3>
+        <p>We believe in substance over style, and we encourage authors to prioritize delivering their message over conforming to a particular template. That being said, we anticipate papers will probably end up in the 4&ndash;6 page range, and we encourage authors to use a two-column format. Papers need not be anonymized.</p>
+        <p>Additionally, while one of the goals of NOPE is to find a home for papers that can sometimes be difficult to publish elsewhere, we do not wish to preclude publication elsewhere. NOPE 2015 will not be indexed with IEEE or ACM, so authors should feel free to expand and submit their work to larger venues. We discourage resubmission of previously published papers, though "second-look" papers or retrospectives fall squarely within the scope of the workshop and are welcomed.</p>
+
+        <h3>Submit</h3>
+        <p>Please submit your papers via email to: <a href="mailto:submissions@nope.pub?subject=Submission">submissions@nope.pub</a> by 11:59pm (anywhere on Earth) on the deadline.</p>
       </div>
     </div>
 


### PR DESCRIPTION
Salient points to double-check:
- suggested page range of 4-6ish, two-column
- it's okay to resubmit NOPE papers elsewhere (it would be wonderful if they got in)
- NOT blind (email submission, plus it's a workshop)
- email address is "submissions@nope.pub"
